### PR TITLE
Arreglar bug en la GUI al empezar juego

### DIFF
--- a/Assets/Scripts/CurrentPlayerIndicator.cs
+++ b/Assets/Scripts/CurrentPlayerIndicator.cs
@@ -8,8 +8,8 @@ public class CurrentPlayerIndicator : MonoBehaviour
 {
     [SerializeField] private TMP_Text playerIndicatorText;
 
-    private void Start() {
-        GameManager.Instance.OnTurnStart += OnTurnStart;
+    private void Awake() {
+        GameManager.OnTurnStart += OnTurnStart;
     }
 
     private void OnTurnStart(object sender, System.EventArgs e) {

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -15,10 +15,10 @@ public class GameManager : MonoBehaviour {
     public Player CurrentPlayer { get; private set; }
     private int currentPlayerIndex;
 
-    public event EventHandler OnRoundStart;
-    public event EventHandler OnTurnStart;
-    public event EventHandler OnTurnEnd;
-    public event EventHandler OnRoundEnd;
+    public static event EventHandler OnRoundStart;
+    public static event EventHandler OnTurnStart;
+    public static event EventHandler OnTurnEnd;
+    public static event EventHandler OnRoundEnd;
 
     private void Awake() {
         Instance = this;

--- a/Assets/Scripts/RoundNoIndicator.cs
+++ b/Assets/Scripts/RoundNoIndicator.cs
@@ -7,8 +7,8 @@ public class RoundNoIndicator : MonoBehaviour
 {
     [SerializeField] private TMP_Text roundNoIndicatorText;
 
-    private void Start() {
-        GameManager.Instance.OnTurnStart += OnRoundStart;
+    private void Awake() {
+        GameManager.OnRoundStart += OnRoundStart;
     }
 
     private void OnRoundStart(object sender, System.EventArgs e) {


### PR DESCRIPTION
Los eventos OnRoundStart y OnTurnStart se disparaban en la función Start de GameManager antes de que los objetos de la GUI RoundNoIndicator y CurrentPlayerIndicator pudiesen suscribirse a los mismos (también durante sus funciones Start). Esto hacía que muestren información incorrecta al empezar el juego (aunque esto se corregía en el siguiente turno).

Hacer a los eventos miembros estáticos de GameManager permite a los objetos registrarse a ellos durante Awake, garantizando que al dispararse los eventos durante Start en GameManager, los mismos sean escuchados por estos objetos.